### PR TITLE
feat: 서버 설정 추가

### DIFF
--- a/src/main/java/com/Main.java
+++ b/src/main/java/com/Main.java
@@ -1,17 +1,44 @@
 package com;
 
-//TIP To <b>Run</b> code, press <shortcut actionId="Run"/> or
-// click the <icon src="AllIcons.Actions.Execute"/> icon in the gutter.
+import com.server.RedisServer;
+import com.server.ServerConfig;
+
 public class Main {
     public static void main(String[] args) {
-        //TIP Press <shortcut actionId="ShowIntentionActions"/> with your caret at the highlighted text
-        // to see how IntelliJ IDEA suggests fixing it.
-        System.out.printf("Hello and welcome!");
+        // Example:
+        //   ./gradlew run --args="--port=6380 --workers=32"
+        //   (IntelliJ → Run Configuration → Program arguments)
+        // This builds ServerConfig from CLI args and starts RedisServer.
+        ServerConfig config = resolveConfig(args);
+        RedisServer server = new RedisServer(config);
+        server.start();
+    }
 
-        for (int i = 1; i <= 5; i++) {
-            //TIP Press <shortcut actionId="Debug"/> to start debugging your code. We have set one <icon src="AllIcons.Debugger.Db_set_breakpoint"/> breakpoint
-            // for you, but you can always add more by pressing <shortcut actionId="ToggleLineBreakpoint"/>.
-            System.out.println("i = " + i);
+    private static ServerConfig resolveConfig(String[] args) {
+        ServerConfig.Builder builder = ServerConfig.builder();
+
+        for (String arg : args) {
+            if (arg.startsWith("--port=")) {
+                builder.port(parsePositiveInt(arg.substring(7), "port"));
+            } else if (arg.startsWith("--backlog=")) {
+                builder.backlog(parsePositiveInt(arg.substring(10), "backlog"));
+            } else if (arg.startsWith("--workers=")) {
+                builder.workerThreads(parsePositiveInt(arg.substring(10), "workers"));
+            }
+        }
+
+        return builder.build();
+    }
+
+    private static int parsePositiveInt(String value, String name) {
+        try {
+            int parsed = Integer.parseInt(value);
+            if (parsed <= 0) {
+                throw new IllegalArgumentException(name + " must be positive.");
+            }
+            return parsed;
+        } catch (NumberFormatException e) {
+            throw new IllegalArgumentException("Invalid " + name + " value: " + value, e);
         }
     }
 }

--- a/src/main/java/com/server/RedisServer.java
+++ b/src/main/java/com/server/RedisServer.java
@@ -1,4 +1,22 @@
 package com.server;
 
 public class RedisServer {
+    private final ServerConfig config;
+
+    public RedisServer(ServerConfig config) {
+        this.config = config;
+    }
+
+    public static RedisServer createDefault() {
+        return new RedisServer(ServerConfig.defaultConfig());
+    }
+
+    public void start() {
+        System.out.printf("MiniRedis Server starting on port %d with %d worker threads...%n",
+                config.port(), config.workerThreads());
+    }
+
+    public ServerConfig getConfig() {
+        return config;
+    }
 }

--- a/src/main/java/com/server/ServerConfig.java
+++ b/src/main/java/com/server/ServerConfig.java
@@ -1,0 +1,85 @@
+package com.server;
+
+import java.time.Duration;
+
+public class ServerConfig {
+    private static final int DEFAULT_PORT = 6379;
+    private static final int DEFAULT_BACKLOG = 50;
+    private static final int DEFAULT_WORKER_THREADS = 16;
+    private static final Duration DEFAULT_SHUTDOWN_TIMEOUT = Duration.ofSeconds(5);
+
+    private final int port;
+    private final int backlog;
+    private final int workerThreads;
+    private final Duration shutdownTimeout;
+
+    private ServerConfig(Builder builder) {
+        this.port = builder.port;
+        this.backlog = builder.backlog;
+        this.workerThreads = builder.workerThreads;
+        this.shutdownTimeout = builder.shutdownTimeout;
+    }
+
+    public static Builder builder() {
+        return new Builder()
+                .port(DEFAULT_PORT)
+                .backlog(DEFAULT_BACKLOG)
+                .workerThreads(DEFAULT_WORKER_THREADS)
+                .shutdownTimeout(DEFAULT_SHUTDOWN_TIMEOUT);
+    }
+
+    public static ServerConfig defaultConfig() {
+        return builder().build();
+    }
+
+    public int port() {
+        return port;
+    }
+
+    public int backlog() {
+        return backlog;
+    }
+
+    public int workerThreads() {
+        return workerThreads;
+    }
+
+    public Duration shutdownTimeout() {
+        return shutdownTimeout;
+    }
+
+    public static final class Builder {
+        private int port = DEFAULT_PORT;
+        private int backlog = DEFAULT_BACKLOG;
+        private int workerThreads = DEFAULT_WORKER_THREADS;
+        private Duration shutdownTimeout = DEFAULT_SHUTDOWN_TIMEOUT;
+
+        private Builder() {
+        }
+
+        public Builder port(int port) {
+            this.port = port;
+            return this;
+        }
+
+        public Builder backlog(int backlog) {
+            this.backlog = backlog;
+            return this;
+        }
+
+        public Builder workerThreads(int workerThreads) {
+            this.workerThreads = workerThreads;
+            return this;
+        }
+
+        public Builder shutdownTimeout(Duration shutdownTimeout) {
+            this.shutdownTimeout = shutdownTimeout;
+            return this;
+        }
+
+        public ServerConfig build() {
+            return new ServerConfig(this);
+        }
+    }
+}
+


### PR DESCRIPTION
- ServerConfig로 포트/스레드 등 설정 분리  
- RedisServer가 설정을 받아 로그 출력하도록 구성  
- Main에서 CLI 인자 파싱 후 서버 실행  

<!-- PR 제목은 최종 커밋 메시지로 사용됩니다 -->
<!-- 형식: [타입]: [간결한 변경 요약] -->
<!-- 예: feat: 캐시 저장 기능 구현 -->

## 요약
> Closes #7

## 변경 내용
- `ServerConfig` 빌더 추가로 포트·백로그·워커 수 기본값 관리
- `RedisServer`가 설정을 주입받아 시작 로그 출력하도록 뼈대 구성
- `Main`에서 CLI 인자(`--port`, `--backlog`, `--workers`) 파싱 후 서버 실행
- 실행 방법 주석 추가로 Gradle/IntelliJ Run 예시 명시

## 체크리스트
- [x] 커밋 메시지 컨벤션을 준수했습니다. (`feat`, `fix`, `refactor`, 등)
- [x] 코드 실행 및 테스트가 정상 동작함을 확인했습니다.
- [x] 변경된 코드에 대한 주석 또는 문서가 적절히 추가되었습니다.
- [x] 적절한 작업 단위로 커밋을 수행했습니다.
- [x] 풀 리퀘스트 제목에 컨벤션을 적용했습니다.
- [x] Assignees에 나를 할당했습니다.
- [x] 리뷰어를 등록했습니다.

## 주의 사항
_No specific notes_

## 실행 예시 / 테스트 결과
./gradlew run --args="--port=6380 --workers=32"
로그: MiniRedis Server starting on port 6380 with 32 worker threads...